### PR TITLE
Add priority argument

### DIFF
--- a/src/Attributes/Any.php
+++ b/src/Attributes/Any.php
@@ -12,6 +12,7 @@ class Any extends Route
         string $uri,
         ?string $name = null,
         array | string $middleware = [],
+        int $priority = 0,
     ) {
         parent::__construct(
             methods: Router::$verbs,

--- a/src/Attributes/ApiResource.php
+++ b/src/Attributes/ApiResource.php
@@ -14,6 +14,7 @@ class ApiResource extends Resource
         public array | string | null $names = null,
         public array | string | null $parameters = null,
         public bool | null $shallow = null,
+        int $priority = 0,
     ) {
         parent::__construct(
             resource: $resource,

--- a/src/Attributes/Delete.php
+++ b/src/Attributes/Delete.php
@@ -11,6 +11,7 @@ class Delete extends Route
         string $uri,
         ?string $name = null,
         array | string $middleware = [],
+        int $priority = 0,
     ) {
         parent::__construct(
             methods: ['delete'],

--- a/src/Attributes/Get.php
+++ b/src/Attributes/Get.php
@@ -11,6 +11,7 @@ class Get extends Route
         string $uri,
         ?string $name = null,
         array | string $middleware = [],
+        int $priority = 0,
     ) {
         parent::__construct(
             methods: ['get'],

--- a/src/Attributes/Options.php
+++ b/src/Attributes/Options.php
@@ -11,6 +11,7 @@ class Options extends Route
         string $uri,
         ?string $name = null,
         array | string $middleware = [],
+        int $priority = 0,
     ) {
         parent::__construct(
             methods: ['options'],

--- a/src/Attributes/Patch.php
+++ b/src/Attributes/Patch.php
@@ -11,6 +11,7 @@ class Patch extends Route
         string $uri,
         ?string $name = null,
         array | string $middleware = [],
+        int $priority = 0,
     ) {
         parent::__construct(
             methods: ['patch'],

--- a/src/Attributes/Post.php
+++ b/src/Attributes/Post.php
@@ -11,6 +11,7 @@ class Post extends Route
         string $uri,
         ?string $name = null,
         array | string $middleware = [],
+        int $priority = 0,
     ) {
         parent::__construct(
             methods: ['post'],

--- a/src/Attributes/Put.php
+++ b/src/Attributes/Put.php
@@ -11,6 +11,7 @@ class Put extends Route
         string $uri,
         ?string $name = null,
         array | string $middleware = [],
+        int $priority = 0,
     ) {
         parent::__construct(
             methods: ['put'],

--- a/src/Attributes/Resource.php
+++ b/src/Attributes/Resource.php
@@ -15,6 +15,7 @@ class Resource implements RouteAttribute
         public array | string | null $names = null,
         public array | string | null $parameters = null,
         public bool | null $shallow = null,
+        int $priority = 0,
     ) {
     }
 }

--- a/src/Attributes/Route.php
+++ b/src/Attributes/Route.php
@@ -18,6 +18,7 @@ class Route implements RouteAttribute
         public string $uri,
         public ?string $name = null,
         array | string $middleware = [],
+        int $priority = 0,
     ) {
         $this->methods = array_map(
             static fn (string $verb) => in_array(


### PR DESCRIPTION
Adds support for a 'priority' argument for standard methods and resources.

Adding a 'priority' argument to a route definition will allow more accurate control over what route should take precedence when registering routes. If a route/method combination has already been registered and a new conflicting method is registered, the one with the higher number will be used.

Example:
```PHP
#[Get('/', priority: 10)]
public function important_page() {
    // this method will run
}

#[Get('/', priority: 5)]
public function not_important_page() {
    // this method will not run
}
```